### PR TITLE
Feat : 캘린더 페이지 구현

### DIFF
--- a/backend/src/controllers/articleController.js
+++ b/backend/src/controllers/articleController.js
@@ -25,7 +25,7 @@ class ArticleController {
 	}
 
 	/**
-	 * GET /api/article/list ?page=1&limit=10
+	 * GET /api/article/list?page=1&limit=10
 	 */
 	static async list(req, res) {
 		const page = parseInt(req.query.page, 10) || 1;
@@ -71,6 +71,30 @@ class ArticleController {
 		} catch (e) {
 			console.log(e.message);
 			return res.status(500).json({ message: 'Failed to retrieve articles' });
+		}
+	}
+
+	/**
+	 * GET /api/article/my/by-date?year=2024&month=9&day=22
+	 */
+	static async showMemberArticlesByDate(req, res) {
+		const member_id = req.state.member.member_id;
+		const { year, month, day } = req.query;
+
+		if (!year || !month) {
+			return res.status(400).send('Year and month are required.');
+		}
+		console.log(year, month, day);
+		try {
+			const data = await ArticleService.getMemberArticlesByDate(member_id, {
+				year,
+				month,
+				day,
+			});
+			return res.status(200).json(data);
+		} catch (e) {
+			console.log(e.message);
+			return res.status(500).json(e.message);
 		}
 	}
 

--- a/backend/src/repositories/articleRepository.js
+++ b/backend/src/repositories/articleRepository.js
@@ -42,6 +42,26 @@ class ArticleRepository {
 		};
 	}
 
+	static async findByAuthorIdAndCreatedAt(
+		authorId,
+		{ year, month, day = null },
+	) {
+		const sql = `SELECT *
+			FROM article
+			WHERE author_id = $1
+			AND EXTRACT(YEAR FROM created_at) = $2
+			AND EXTRACT(MONTH FROM created_at) = $3
+			${day ? 'AND EXTRACT(DAY FROM created_at) = $4' : ''}
+			ORDER BY article_id `;
+
+		const params = day ? [authorId, year, month, day] : [authorId, year, month];
+		const result = await pool.query(sql, params);
+		return {
+			data: result.rows,
+			count: result.rows.length,
+		};
+	}
+
 	static async update({ articleId, title, subtitle, content }) {
 		const result = await pool.query(
 			`UPDATE article 

--- a/backend/src/routes/articleRouter.js
+++ b/backend/src/routes/articleRouter.js
@@ -7,6 +7,11 @@ const articleRouter = Router();
 
 articleRouter.post('/write', checkLoggedIn, ArticleController.writeArticle);
 articleRouter.get('/my', checkLoggedIn, ArticleController.showMemberArticles);
+articleRouter.get(
+	'/my/by-date',
+	checkLoggedIn,
+	ArticleController.showMemberArticlesByDate,
+);
 articleRouter.get('/list', ArticleController.list);
 articleRouter.get('/detail/:articleId', ArticleController.showArticle);
 articleRouter.patch(

--- a/backend/src/services/articleService.js
+++ b/backend/src/services/articleService.js
@@ -32,6 +32,14 @@ class ArticleService {
 		return result;
 	}
 
+	static async getMemberArticlesByDate(memberId, params) {
+		const result = await ArticleRepository.findByAuthorIdAndCreatedAt(
+			memberId,
+			params,
+		);
+		return result;
+	}
+
 	static async updateArticle({ articleId, title, subtitle, content }) {
 		const result = await ArticleRepository.update({
 			articleId,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
 		"@testing-library/react": "^13.0.0",
 		"@testing-library/user-event": "^13.2.1",
 		"axios": "^1.7.7",
+		"date-fns": "^4.1.0",
 		"dotenv": "^16.4.5",
 		"immer": "^10.1.1",
 		"react": "^18.3.1",

--- a/frontend/src/Router.js
+++ b/frontend/src/Router.js
@@ -8,7 +8,8 @@ import WritePage from './pages/WritePage';
 import ArticlePage from './pages/ArticlePage';
 import Layout from './containers/common/Layout';
 import MyArticlesPage from './pages/MyArticlesPage';
-import ArticleFeedPage from './pages/ArticleFeedPage';
+import FullArticlesPage from './pages/FullArticlesPage';
+import CalendarPage from './pages/CalendarPage';
 
 const Router = () => {
 	return (
@@ -16,14 +17,15 @@ const Router = () => {
 			<Routes>
 				<Route element={<Layout />}>
 					<Route path="/" element={<MainPage />} />
-					<Route path="oauth2/redirect" element={<OAuth2RedirectHandler />} />
 					<Route path="write" element={<WritePage />} />
-					<Route path="articles" element={<ArticleFeedPage />} />
+					<Route path="articles" element={<FullArticlesPage />} />
 					<Route path="my" element={<MyArticlesPage />} />
 					<Route path="article/:articleId" element={<ArticlePage />} />
+					<Route path="calendar" element={<CalendarPage />} />
 				</Route>
 				<Route path="/login" element={<LoginPage />} />
 				<Route path="/register" element={<RegisterPage />} />
+				<Route path="/oauth2/redirect" element={<OAuth2RedirectHandler />} />
 			</Routes>
 		</BrowserRouter>
 	);

--- a/frontend/src/components/article/FullArticlesView.js
+++ b/frontend/src/components/article/FullArticlesView.js
@@ -1,16 +1,17 @@
 import React from 'react';
-import styled from 'styled-components';
 import Responsive from '../common/Responsive';
+import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { formatDate } from '../../utils/dateUtils';
 
-const MyArticlesBlock = styled(Responsive)`
+const FullArticlesBlock = styled(Responsive)`
 	padding: 10rem;
 	padding-bottom: 1rem;
 	max-width: 1300px;
+	min-width: 800px;
 `;
 
-const ArticleWrapper = styled.div`
+const FullArticlesWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -48,12 +49,21 @@ const ArticleItem = styled(Link)`
 			text-decoration: underline;
 		}
 	}
+	.info {
+		span {
+			padding-right: 1rem;
+		}
+		.author {
+			font-style: italic;
+			font-size: 0.8rem;
+		}
+	}
 `;
 
-const MyArticles = ({ articles, error, loading }) => {
+const FullArticlesView = ({ articles }) => {
 	return (
-		<MyArticlesBlock>
-			<ArticleWrapper>
+		<FullArticlesBlock>
+			<FullArticlesWrapper>
 				{articles &&
 					articles.data.map((article) => (
 						<ArticleItem key={article.article_id} to={`/article/${article.article_id}`}>
@@ -62,12 +72,15 @@ const MyArticles = ({ articles, error, loading }) => {
 								{article.subtitle && <span className="subtitle">{article.subtitle}</span>}
 								{article.content.replace(/(<([^>]+)>)/gi, '')}
 							</div>
-							<div className="createdAt">{formatDate(article.created_at)}</div>
+							<div className="info">
+								<span className="createdAt">{formatDate(article.created_at)}</span>
+								<span className="author">by {article.author_nickname}</span>
+							</div>
 						</ArticleItem>
 					))}
-			</ArticleWrapper>
-		</MyArticlesBlock>
+			</FullArticlesWrapper>
+		</FullArticlesBlock>
 	);
 };
 
-export default MyArticles;
+export default FullArticlesView;

--- a/frontend/src/components/article/MyArticlesView.js
+++ b/frontend/src/components/article/MyArticlesView.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import Responsive from '../common/Responsive';
 import styled from 'styled-components';
+import Responsive from '../common/Responsive';
 import { Link } from 'react-router-dom';
 import { formatDate } from '../../utils/dateUtils';
 
-const ArticleFeedBlock = styled(Responsive)`
+const MyArticlesBlock = styled(Responsive)`
 	padding: 10rem;
 	padding-bottom: 1rem;
 	max-width: 1300px;
@@ -48,20 +48,11 @@ const ArticleItem = styled(Link)`
 			text-decoration: underline;
 		}
 	}
-	.info {
-		span {
-			padding-right: 1rem;
-		}
-		.author {
-			font-style: italic;
-			font-size: 0.8rem;
-		}
-	}
 `;
 
-const ArticleFeed = ({ articles }) => {
+const MyArticlesView = ({ articles, error, loading }) => {
 	return (
-		<ArticleFeedBlock>
+		<MyArticlesBlock>
 			<ArticleWrapper>
 				{articles &&
 					articles.data.map((article) => (
@@ -71,15 +62,12 @@ const ArticleFeed = ({ articles }) => {
 								{article.subtitle && <span className="subtitle">{article.subtitle}</span>}
 								{article.content.replace(/(<([^>]+)>)/gi, '')}
 							</div>
-							<div className="info">
-								<span className="createdAt">{formatDate(article.created_at)}</span>
-								<span className="author">by {article.author_nickname}</span>
-							</div>
+							<div className="createdAt">{formatDate(article.created_at)}</div>
 						</ArticleItem>
 					))}
 			</ArticleWrapper>
-		</ArticleFeedBlock>
+		</MyArticlesBlock>
 	);
 };
 
-export default ArticleFeed;
+export default MyArticlesView;

--- a/frontend/src/components/calendar/ArticleCalendarView.js
+++ b/frontend/src/components/calendar/ArticleCalendarView.js
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import CalendarSection from './CalendarSection';
+import Responsive from '../common/Responsive';
+import ArticleListSection from './ArticleListSection';
+import useCalendar from '../../hooks/useCalendar';
+
+const ArticleCalendarViewBlock = styled(Responsive)`
+	padding: 7rem 7rem;
+	padding-bottom: 1rem;
+	max-width: 1400px;
+	/* border: 1px solid gray; */
+`;
+
+const ArticleCalendarViewWrapper = styled.div`
+	width: 100%;
+	display: flex;
+	flex-direction: row;
+	align-items: start;
+	justify-content: center;
+	@media (max-width: 1000px) {
+		flex-direction: column;
+		align-items: center;
+	}
+`;
+
+const ArticleCalendarView = ({ articles, onDateChange, articlesForMonth }) => {
+	const {
+		selectedYear,
+		selectedMonth,
+		selectedDay,
+		weeks,
+		handlePrevYear,
+		handleNextYear,
+		handlePrevMonth,
+		handleNextMonth,
+		handleSelectedDay,
+	} = useCalendar();
+
+	useEffect(() => {
+		console.log(`selectedYear's changed.`);
+		onDateChange({
+			key: 'year',
+			value: selectedYear,
+		});
+	}, [onDateChange, selectedYear]);
+
+	useEffect(() => {
+		console.log(`selectedMonth's changed.`);
+		onDateChange({
+			key: 'month',
+			value: selectedMonth,
+		});
+	}, [onDateChange, selectedMonth]);
+
+	useEffect(() => {
+		console.log(`selectedDay's changed.`);
+		onDateChange({
+			key: 'day',
+			value: selectedDay,
+		});
+	}, [onDateChange, selectedDay]);
+
+	return (
+		<ArticleCalendarViewBlock>
+			<ArticleCalendarViewWrapper>
+				<CalendarSection
+					selectedYear={selectedYear}
+					selectedMonth={selectedMonth}
+					selectedDay={selectedDay}
+					weeks={weeks}
+					handlePrevYear={handlePrevYear}
+					handleNextYear={handleNextYear}
+					handleNextMonth={handleNextMonth}
+					handlePrevMonth={handlePrevMonth}
+					handleDaySelect={handleSelectedDay}
+					articles={articles}
+					articlesForMonth={articlesForMonth}
+				/>
+				<ArticleListSection
+					articles={articles}
+					selectedYear={selectedYear}
+					selectedMonth={selectedMonth}
+					selectedDay={selectedDay}
+				/>
+			</ArticleCalendarViewWrapper>
+		</ArticleCalendarViewBlock>
+	);
+};
+
+export default ArticleCalendarView;

--- a/frontend/src/components/calendar/ArticleListSection.js
+++ b/frontend/src/components/calendar/ArticleListSection.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import { formatDate } from '../../utils/dateUtils';
+
+const ArticleListBlock = styled.div`
+	position: relative;
+	width: 600px;
+	max-height: 600px;
+	padding: 1rem;
+	margin: 1rem;
+	/* border: 1px solid gray; */
+	overflow-y: scroll;
+`;
+
+const ArticleItem = styled(Link)`
+	font-size: 17px;
+	width: 100%;
+	height: 120px;
+	border-bottom: 1px solid gray;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	align-items: start;
+	padding: 1.125rem 0;
+	color: var(--color-dark-gray);
+	.title {
+		font-size: 19px;
+		font-weight: 500;
+		color: var(--color-black);
+	}
+	.subtitle {
+		color: var(--color-black);
+		padding-right: 0.5rem;
+	}
+	.content {
+		width: 100%;
+		overflow: hidden; /* 넘치는 부분 가리기 */
+		text-overflow: ellipsis; /* ... 처리하기 */
+		white-space: nowrap; /* 줄바꿈 안하기 (한 줄 밑줄임표 적용) */
+	}
+	&:hover {
+		cursor: pointer;
+		.title {
+			text-decoration: underline;
+		}
+	}
+	.info {
+		span {
+			padding-right: 1rem;
+		}
+		.author {
+			font-style: italic;
+			font-size: 0.8rem;
+		}
+	}
+`;
+
+const ArticleListHeader = styled.div`
+	width: 100%;
+	height: 20px;
+	background-color: white;
+	text-align: center;
+`;
+
+const ArticleListSection = ({ articles }) => {
+	return (
+		<ArticleListBlock>
+			<ArticleListHeader>{articles && <div>총 {articles.length}개의 글</div>}</ArticleListHeader>
+			{articles && articles.length > 0
+				? articles.map((article, idx) => (
+						<ArticleItem key={`article${idx}`} to={`/article/${article.article_id}`}>
+							<h2 className="title">{article.title}</h2>
+							<div className="content">
+								{article.subtitle && <span className="subtitle">{article.subtitle}</span>}
+								{article.content.replace(/(<([^>]+)>)/gi, '')}
+							</div>
+							<div className="createdAt">{formatDate(article.created_at)}</div>
+						</ArticleItem>
+				  ))
+				: null}
+		</ArticleListBlock>
+	);
+};
+
+export default ArticleListSection;

--- a/frontend/src/components/calendar/CalendarSection.js
+++ b/frontend/src/components/calendar/CalendarSection.js
@@ -1,0 +1,205 @@
+import React, { useEffect } from 'react';
+import styled, { css } from 'styled-components';
+import { format } from 'date-fns';
+import LeftArrow from '../../images/LeftArrow.svg';
+import RightArrow from '../../images/RightArrow.svg';
+const CalendarBlock = styled.div`
+	min-width: 350px;
+	max-height: 400px;
+	padding: 1rem;
+	margin: 1rem;
+	/* border: 1px solid gray; */
+	/* background-color: var(--color-light-gray); */
+`;
+
+/**
+ * Header
+ */
+
+const CalendarHeader = styled.div`
+	height: 45px;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+	/* border: 1px solid gray; */
+	.left {
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
+	}
+	.right {
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
+	}
+	.btn {
+		padding: 0.125rem;
+		cursor: pointer;
+	}
+	span {
+		padding: 0.125rem;
+		font-size: large;
+		font-weight: 600;
+	}
+`;
+
+/**
+ * Day List
+ */
+const dayList = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+const CalendarDayListWrapper = styled.div`
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.5rem 0;
+	/* border: 1px solid gray; */
+`;
+const CalendarDayList = styled.span`
+	/* border: 1px solid gray; */
+	width: 12%;
+	text-align: center;
+	line-height: 100%;
+	${({ $sat }) =>
+		$sat &&
+		css`
+			color: royalblue;
+		`}
+	${({ $sun }) =>
+		$sun &&
+		css`
+			color: tomato;
+		`}
+`;
+
+/**
+ * Body
+ */
+
+const CalendarBody = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+`;
+
+const WeekItem = styled.div`
+	width: 100%;
+	padding: 0.5rem 0;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+`;
+const DayItem = styled.div`
+	width: 30px;
+	height: 30px;
+	text-align: center;
+	line-height: 30px;
+	border-radius: 100px;
+	scale: 0.9;
+	${({ $notThisMonth }) =>
+		$notThisMonth &&
+		css`
+			visibility: hidden;
+		`}
+	${({ $hasArticle }) =>
+		$hasArticle &&
+		css`
+			cursor: pointer;
+			border: 1px solid gray;
+			&:hover {
+				scale: 1;
+			}
+		`}
+		${({ $clicked }) =>
+		$clicked &&
+		css`
+			background-color: var(--color-light-gray);
+		`}
+`;
+
+const month = {
+	0: 'jan',
+	1: 'feb',
+	2: 'mar',
+	3: 'april',
+	4: 'may',
+	5: 'june',
+	6: 'july',
+	7: 'aug',
+	8: 'sep',
+	9: 'oct',
+	10: 'nov',
+	11: 'dec',
+};
+
+const CalendarSection = ({
+	selectedYear,
+	selectedMonth,
+	selectedDay,
+	handlePrevYear,
+	handleNextYear,
+	handlePrevMonth,
+	handleNextMonth,
+	handleDaySelect,
+	weeks,
+	articlesForMonth,
+}) => {
+	const hasArticleOnDate = (date) => {
+		// 해당 날짜에 글이 있는지 체크하는 함수
+		if (articlesForMonth) {
+			const formattedDate = format(date, 'yyyy-MM-dd');
+			return articlesForMonth.some(
+				(article) => format(new Date(article.created_at), 'yyyy-MM-dd') === formattedDate,
+			);
+		}
+	};
+
+	return (
+		<CalendarBlock>
+			<CalendarHeader>
+				<div className="left">
+					<img className="btn" src={LeftArrow} alt="prev year" onClick={handlePrevYear} />
+					<span>{selectedYear}</span>
+					<img className="btn" src={RightArrow} alt="next year" onClick={handleNextYear} />
+				</div>
+				<div className="right">
+					<img className="btn" src={LeftArrow} alt="prev month" onClick={handlePrevMonth} />
+					<span>{month[selectedMonth]}</span>
+					<img className="btn" src={RightArrow} alt="next month" onClick={handleNextMonth} />
+				</div>
+			</CalendarHeader>
+			<CalendarDayListWrapper>
+				{dayList.map((day) => (
+					<CalendarDayList key={day} $sat={day === 'sat'} $sun={day === 'sun'}>
+						{day}
+					</CalendarDayList>
+				))}
+			</CalendarDayListWrapper>
+			<CalendarBody>
+				{weeks.map((week, idx) => (
+					<WeekItem key={`week${idx}`}>
+						{week.map((day) => {
+							const text = format(day, 'd');
+							const hasArticle = hasArticleOnDate(day); // 해당 날짜에 글이 있는지 확인
+							return (
+								<DayItem
+									$notThisMonth={day.getMonth() !== selectedMonth}
+									$clicked={day.getDate() === selectedDay}
+									$hasArticle={hasArticle}
+									key={`${idx}-${day}`}
+									onClick={() => (hasArticle ? handleDaySelect(day) : null)}
+								>
+									{text}
+								</DayItem>
+							);
+						})}
+					</WeekItem>
+				))}
+			</CalendarBody>
+		</CalendarBlock>
+	);
+};
+
+export default CalendarSection;

--- a/frontend/src/components/common/Header.js
+++ b/frontend/src/components/common/Header.js
@@ -8,8 +8,8 @@ import Left from '../../images/light/Left.svg';
 const HeaderBlock = styled.div`
 	position: fixed;
 	width: 100%;
-	background-color: var(--color-light-gray);
-	box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.08);
+	background-color: white;
+	/* box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.08); */
 	z-index: 101;
 `;
 
@@ -45,6 +45,16 @@ const Menu = styled.div`
 	padding-right: 1rem; // Responsive의 padding-left와 동일하게
 `;
 
+const Login = styled(Link)`
+	height: 35px;
+	width: 80px;
+	text-align: center;
+	line-height: 35px;
+	border: 1px solid var(--color-gray);
+	border-radius: 100px;
+	font-size: 16px;
+`;
+
 const Header = ({ user, onLogout, onMenuBtnClick }) => {
 	return (
 		<>
@@ -64,9 +74,9 @@ const Header = ({ user, onLogout, onMenuBtnClick }) => {
 							<span onClick={onLogout}>로그아웃</span>
 						</div>
 					) : (
-						<Link to="/login" className="right">
+						<Login to="/login" className="right">
 							시작하기
-						</Link>
+						</Login>
 					)}
 				</Wrapper>
 			</HeaderBlock>

--- a/frontend/src/components/common/Sidebar.js
+++ b/frontend/src/components/common/Sidebar.js
@@ -14,7 +14,8 @@ const SideBarBlock = styled.div`
 	right: 0;
 	width: calc(1rem + 70px);
 	height: 100%;
-	background-color: var(--color-light-gray);
+	background-color: white;
+	/* box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.08); */
 	z-index: 101;
 	padding-left: 1rem;
 	transition: transform 0.3s ease-in-out;
@@ -74,7 +75,9 @@ const Sidebar = ({ isSidebarClosed, onMenuBtnClick }) => {
 						</Link>
 					</SideMenuItem>
 					<SideMenuItem>
-						<img className="btn" src={Calendar} alt="calendar" />
+						<Link to="/calendar">
+							<img className="btn" src={Calendar} alt="calendar" />
+						</Link>
 					</SideMenuItem>
 					<SideMenuItem>
 						<Link to="/write">

--- a/frontend/src/containers/article/FullArticlesContainer.js
+++ b/frontend/src/containers/article/FullArticlesContainer.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import ArticleFeed from '../../components/article/ArticleFeed';
+import FullArticlesView from '../../components/article/FullArticlesView';
 import PaginationBar from '../../components/pagination/PaginationBar';
 import { readAllArticles, unloadArticles } from '../../modules/article/articles/articlesActions';
 
-const ArticleFeedContainer = () => {
+const FullArticlesContainer = () => {
 	const limit = 10;
 	const dispatch = useDispatch();
 
@@ -16,7 +16,6 @@ const ArticleFeedContainer = () => {
 	const totalCnt = articles ? parseInt(articles.count) : 0;
 
 	useEffect(() => {
-		console.log(`limit : ${limit}, page:${page} dispatch`);
 		dispatch(readAllArticles({ limit, page }));
 
 		return () => {
@@ -30,7 +29,7 @@ const ArticleFeedContainer = () => {
 
 	return (
 		<>
-			<ArticleFeed articles={articles} error={error} loading={loading} />
+			<FullArticlesView articles={articles} error={error} loading={loading} />
 			<PaginationBar
 				totalItemCnt={totalCnt}
 				currentPage={page}
@@ -42,4 +41,4 @@ const ArticleFeedContainer = () => {
 	);
 };
 
-export default ArticleFeedContainer;
+export default FullArticlesContainer;

--- a/frontend/src/containers/article/MyArticlesContainer.js
+++ b/frontend/src/containers/article/MyArticlesContainer.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import MyArticles from '../../components/article/MyArticles';
+import MyArticlesView from '../../components/article/MyArticlesView';
 import { useDispatch, useSelector } from 'react-redux';
 import { readMyArticles, unloadArticles } from '../../modules/article/articles/articlesActions';
 import PaginationBar from '../../components/pagination/PaginationBar';
@@ -33,7 +33,7 @@ const MyArticlesContainer = () => {
 
 	return (
 		<>
-			<MyArticles articles={articles} error={error} loading={loading} />
+			<MyArticlesView articles={articles} error={error} loading={loading} />
 			<PaginationBar totalItemCnt={totalCnt} currentPage={page} onPageChange={onPageChange} />
 		</>
 	);

--- a/frontend/src/containers/calendar/ArticleCalendarContainer.js
+++ b/frontend/src/containers/calendar/ArticleCalendarContainer.js
@@ -1,0 +1,57 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import ArticleCalendarView from '../../components/calendar/ArticleCalendarView';
+import useCalendar from '../../hooks/useCalendar';
+import { getArticles, getArticlesByDate, initialize } from '../../modules/calendar/calendarActions';
+const ArticleCalendarContainer = () => {
+	const dispatch = useDispatch();
+	const error = useSelector((state) => state.calendar.articles.error);
+	const articles = useSelector((state) => state.calendar.articles.data);
+	const articlesForMonth = useSelector((state) => state.calendar.articlesForMonth.data);
+	const { selectedYear, selectedMonth } = useCalendar();
+	const [year, setYear] = useState(selectedYear);
+	const [month, setMonth] = useState(selectedMonth);
+	const [day, setDay] = useState(null);
+
+	useEffect(() => {
+		dispatch(getArticles({ year, month: month + 1 }));
+		return () => {
+			dispatch(initialize());
+		};
+	}, [dispatch, year, month]);
+
+	useEffect(() => {
+		console.log(error);
+	}, [error]);
+
+	const onDateChange = useCallback(
+		({ key, value }) => {
+			console.log(key, value);
+			switch (key) {
+				case 'year':
+					setYear(() => value);
+					break;
+				case 'month':
+					setMonth(() => value);
+					break;
+				case 'day':
+					setDay(() => value);
+					dispatch(getArticlesByDate({ year, month: month + 1, day: value }));
+					break;
+				default:
+					console.log('wrong key');
+			}
+		},
+		[dispatch, year, month],
+	);
+
+	return (
+		<ArticleCalendarView
+			articles={articles}
+			articlesForMonth={articlesForMonth}
+			onDateChange={onDateChange}
+		/>
+	);
+};
+
+export default ArticleCalendarContainer;

--- a/frontend/src/hooks/useCalendar.js
+++ b/frontend/src/hooks/useCalendar.js
@@ -1,20 +1,36 @@
 import { useState } from 'react';
 import {
 	addMonths,
+	addYears,
 	eachDayOfInterval,
 	endOfMonth,
 	endOfWeek,
+	getDate,
 	getMonth,
 	getYear,
 	startOfMonth,
 	startOfWeek,
 	subMonths,
+	subYears,
 } from 'date-fns';
 
 const useCalendar = () => {
 	const [currentDate, setCurrentDate] = useState(new Date()); // 현재 날짜
 	const [selectedYear, setSelectedYear] = useState(getYear(currentDate));
 	const [selectedMonth, setSelectedMonth] = useState(getMonth(currentDate));
+	const [selectedDay, setSelectedDay] = useState(null);
+
+	const handlePrevYear = () => {
+		const prevYear = subYears(new Date(selectedYear, selectedMonth), 1);
+		setSelectedYear(getYear(prevYear));
+		setSelectedMonth(getMonth(prevYear));
+	};
+
+	const handleNextYear = () => {
+		const nextMonth = addYears(new Date(selectedYear, selectedMonth), 1);
+		setSelectedYear(getYear(nextMonth));
+		setSelectedMonth(getMonth(nextMonth));
+	};
 
 	const handlePrevMonth = () => {
 		const prevMonth = subMonths(new Date(selectedYear, selectedMonth), 1);
@@ -26,6 +42,11 @@ const useCalendar = () => {
 		const nextMonth = addMonths(new Date(selectedYear, selectedMonth), 1);
 		setSelectedYear(getYear(nextMonth));
 		setSelectedMonth(getMonth(nextMonth));
+	};
+
+	const handleSelectedDay = (date) => {
+		console.log('current date', date);
+		setSelectedDay(getDate(date));
 	};
 
 	const days = eachDayOfInterval({
@@ -45,9 +66,13 @@ const useCalendar = () => {
 	return {
 		selectedYear,
 		selectedMonth,
+		selectedDay,
 		weeks,
+		handlePrevYear,
+		handleNextYear,
 		handlePrevMonth,
 		handleNextMonth,
+		handleSelectedDay,
 	};
 };
 

--- a/frontend/src/hooks/useCalendar.js
+++ b/frontend/src/hooks/useCalendar.js
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import {
+	addMonths,
+	eachDayOfInterval,
+	endOfMonth,
+	endOfWeek,
+	getMonth,
+	getYear,
+	startOfMonth,
+	startOfWeek,
+	subMonths,
+} from 'date-fns';
+
+const useCalendar = () => {
+	const [currentDate, setCurrentDate] = useState(new Date()); // 현재 날짜
+	const [selectedYear, setSelectedYear] = useState(getYear(currentDate));
+	const [selectedMonth, setSelectedMonth] = useState(getMonth(currentDate));
+
+	const handlePrevMonth = () => {
+		const prevMonth = subMonths(new Date(selectedYear, selectedMonth), 1);
+		setSelectedYear(getYear(prevMonth));
+		setSelectedMonth(getMonth(prevMonth));
+	};
+
+	const handleNextMonth = () => {
+		const nextMonth = addMonths(new Date(selectedYear, selectedMonth), 1);
+		setSelectedYear(getYear(nextMonth));
+		setSelectedMonth(getMonth(nextMonth));
+	};
+
+	const days = eachDayOfInterval({
+		start: startOfWeek(startOfMonth(new Date(selectedYear, selectedMonth)), {
+			weekStartsOn: 1,
+		}),
+		end: endOfWeek(endOfMonth(new Date(selectedYear, selectedMonth)), {
+			weekStartsOn: 1,
+		}),
+	});
+
+	const weeks = [];
+	for (let i = 0; i < days.length; i += 7) {
+		weeks.push(days.slice(i, i + 7));
+	}
+
+	return {
+		selectedYear,
+		selectedMonth,
+		weeks,
+		handlePrevMonth,
+		handleNextMonth,
+	};
+};
+
+export default useCalendar;

--- a/frontend/src/images/LeftArrow.svg
+++ b/frontend/src/images/LeftArrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 5L9.66939 11.2191C9.2842 11.6684 9.2842 12.3316 9.66939 12.7809L15 19" stroke="#2B3F6C" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/images/RightArrow.svg
+++ b/frontend/src/images/RightArrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 19L14.3306 12.7809C14.7158 12.3316 14.7158 11.6684 14.3306 11.2191L9 5" stroke="#2B3F6C" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/modules/calendar/calendarActions.js
+++ b/frontend/src/modules/calendar/calendarActions.js
@@ -1,0 +1,16 @@
+import { createAction } from 'redux-actions';
+import { GET_ARTICLES, GET_ARTICLES_BY_DATE, INITIALIZE } from './calendarTypes';
+
+export const initialize = createAction(INITIALIZE);
+export const getArticles = createAction(GET_ARTICLES, ({ year, month }) => ({
+	year,
+	month,
+}));
+export const getArticlesByDate = createAction(
+	GET_ARTICLES_BY_DATE,
+	({ year, month, day = null }) => ({
+		year,
+		month,
+		day,
+	}),
+);

--- a/frontend/src/modules/calendar/calendarReducer.js
+++ b/frontend/src/modules/calendar/calendarReducer.js
@@ -1,0 +1,46 @@
+import { handleActions } from 'redux-actions';
+import {
+	GET_ARTICLES_BY_DATE_SUCCESS,
+	GET_ARTICLES_BY_DATE_FAILURE,
+	GET_ARTICLES_FAILURE,
+	GET_ARTICLES_SUCCESS,
+	INITIALIZE,
+} from './calendarTypes';
+
+const initialState = {
+	articles: {
+		data: null,
+		count: null,
+	},
+	articlesForMonth: {
+		data: null,
+		count: null,
+	},
+	error: null,
+};
+
+const calendar = handleActions(
+	{
+		[INITIALIZE]: (state) => initialState,
+		[GET_ARTICLES_SUCCESS]: (state, { payload: articles }) => ({
+			...state,
+			articles,
+			articlesForMonth: articles,
+		}),
+		[GET_ARTICLES_FAILURE]: (state, { payload: error }) => ({
+			...state,
+			error,
+		}),
+		[GET_ARTICLES_BY_DATE_SUCCESS]: (state, { payload: articles }) => ({
+			...state,
+			articles,
+		}),
+		[GET_ARTICLES_BY_DATE_FAILURE]: (state, { payload: error }) => ({
+			...state,
+			error,
+		}),
+	},
+	initialState,
+);
+
+export default calendar;

--- a/frontend/src/modules/calendar/calendarSaga.js
+++ b/frontend/src/modules/calendar/calendarSaga.js
@@ -1,0 +1,14 @@
+import { takeLatest } from 'redux-saga/effects';
+import * as articleAPI from '../../services/api/articleAPI.js';
+import createRequestSaga from '../../services/createRequestSaga.js';
+import { GET_ARTICLES, GET_ARTICLES_BY_DATE } from './calendarTypes.js';
+
+export const getArticlesSaga = createRequestSaga(GET_ARTICLES, articleAPI.getMyArticlesByDate);
+export const getArticlesByDateSaga = createRequestSaga(
+	GET_ARTICLES_BY_DATE,
+	articleAPI.getMyArticlesByDate,
+);
+export function* calendarSaga() {
+	yield takeLatest(GET_ARTICLES, getArticlesSaga);
+	yield takeLatest(GET_ARTICLES_BY_DATE, getArticlesByDateSaga);
+}

--- a/frontend/src/modules/calendar/calendarTypes.js
+++ b/frontend/src/modules/calendar/calendarTypes.js
@@ -1,0 +1,7 @@
+import { createRequestActionTypes } from '../../services/createRequestSaga';
+
+export const INITIALIZE = 'calendar/INITIALIZE';
+export const [GET_ARTICLES, GET_ARTICLES_SUCCESS, GET_ARTICLES_FAILURE] =
+	createRequestActionTypes('calendar/GET_ARTICLES');
+export const [GET_ARTICLES_BY_DATE, GET_ARTICLES_BY_DATE_SUCCESS, GET_ARTICLES_BY_DATE_FAILURE] =
+	createRequestActionTypes('calendar/GET_ARTICLES_BY_DATE');

--- a/frontend/src/modules/index.js
+++ b/frontend/src/modules/index.js
@@ -7,6 +7,8 @@ import { articleEditorSaga } from './article/editor/articleEditorSaga';
 import user, { userSaga } from './user/user';
 import { articlesSaga } from './article/articles/articlesSaga';
 import articles from './article/articles/articlesReducer';
+import calendar from './calendar/calendarReducer';
+import { calendarSaga } from './calendar/calendarSaga';
 
 const rootReducer = combineReducers({
 	auth,
@@ -14,10 +16,11 @@ const rootReducer = combineReducers({
 	user,
 	articleEditor,
 	articles,
+	calendar,
 });
 
 export function* rootSaga() {
-	yield all([authSaga(), userSaga(), articleEditorSaga(), articlesSaga()]);
+	yield all([authSaga(), userSaga(), articleEditorSaga(), articlesSaga(), calendarSaga()]);
 }
 
 export default rootReducer;

--- a/frontend/src/pages/ArticleFeedPage.js
+++ b/frontend/src/pages/ArticleFeedPage.js
@@ -1,8 +1,0 @@
-import React from 'react';
-import ArticleFeedContainer from '../containers/article/ArticleFeedContainer';
-
-const ArticleFeedPage = () => {
-	return <ArticleFeedContainer />;
-};
-
-export default ArticleFeedPage;

--- a/frontend/src/pages/CalendarPage.js
+++ b/frontend/src/pages/CalendarPage.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ArticleCalendarContainer from '../containers/calendar/ArticleCalendarContainer';
+
+const CalendarPage = () => {
+	return <ArticleCalendarContainer />;
+};
+
+export default CalendarPage;

--- a/frontend/src/pages/FullArticlesPage.js
+++ b/frontend/src/pages/FullArticlesPage.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import FullArticlesContainer from '../containers/article/FullArticlesContainer';
+
+const FullArticlesPage = () => {
+	return <FullArticlesContainer />;
+};
+
+export default FullArticlesPage;

--- a/frontend/src/services/api/articleAPI.js
+++ b/frontend/src/services/api/articleAPI.js
@@ -11,6 +11,12 @@ export const getArticle = (articleId) => client.get(`/api/article/detail/${artic
 export const getMyArticles = ({ page, limit }) =>
 	client.get(`/api/article/my?page=${page}&limit=${limit}`);
 
+// 본인 작성 글 조회 by Date
+export const getMyArticlesByDate = ({ year, month, day = null }) =>
+	day === null
+		? client.get(`api/article/my/by-date?year=${year}&month=${month}`)
+		: client.get(`api/article/my/by-date?year=${year}&month=${month}&day=${day}`);
+
 // 글 수정
 export const modifyArticle = ({ articleId, title, subtitle, content }) =>
 	client.patch(`/api/article/${articleId}`, { articleId, title, subtitle, content });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3807,6 +3807,11 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 debug@2.6.9, debug@^2.6.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
- 캘린더 라이브러리는 사용하지 않고, date-fns 라이브러리를 사용하여 직접 캘린더 구현
- useCalendar Hook 작성하여 사용

[ 캘린더 페이지 ]
- 진입시 현재 달(Month) 캘린더 화면으로 기본 설정, 모든 articles 리스트가 조회 됨
- Year / Month 이전/이후로 이동 가능
- 특정 날짜 클릭시, 해당 날짜에 해당하는 articles 리스트 조회
- articles 리스트 중 특정 article 클릭 시 해당 조회 페이지로 이동

this closes #16 