### PR TITLE
[#25] Fix :  글 수정 중 페이지 이탈 시에도 기존 정보 삭제 되도록 수정

### DIFF
--- a/frontend/src/containers/article/EditorContainer.js
+++ b/frontend/src/containers/article/EditorContainer.js
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import Editor from '../../components/article/Editor';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -47,6 +47,12 @@ const EditorContainer = () => {
 	};
 
 	useEffect(() => {
+		return () => {
+			dispatch(initialize());
+		};
+	}, []);
+
+	useEffect(() => {
 		if (!originalArticle) {
 			dispatch(initialize());
 		}
@@ -56,7 +62,7 @@ const EditorContainer = () => {
 		if (article) {
 			const { article_id } = article;
 			dispatch(initialize());
-			navigate(`/article/${article_id}`);
+			navigate(`/article/${article_id}`, { replace: true });
 		}
 		if (articleError) {
 			console.log(articleError);

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -27,9 +27,9 @@ loadUser();
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-	<React.StrictMode>
-		<Provider store={store}>
-			<App />
-		</Provider>
-	</React.StrictMode>,
+	// <React.StrictMode>
+	<Provider store={store}>
+		<App />
+	</Provider>,
+	// </React.StrictMode>,
 );


### PR DESCRIPTION
- cleanup 함수로 initialize 디스패치
- React의 StricMode 사용 시 렌더링을 두 번씩 진행하여 글 수정을 위한 페이지 진입 시에도 clenup 함수인 initialize가 실행 되는 것을 확인하였습니다. StricMode 해제 시 원하는 대로 작동 됩니다.

this closes #25 