### PR TITLE
Feat : 닉네임 중복 불가 로직 적용

### DIFF
--- a/backend/src/constants/error/authErrorMessage.js
+++ b/backend/src/constants/error/authErrorMessage.js
@@ -7,6 +7,10 @@ const AuthErrorMessage = {
 		message: '이미 사용 중인 닉네임입니다.',
 		status: 409,
 	},
+	NICKNAME_REQUIRED: {
+		message: '닉네임 설정이 필요합니다.',
+		status: 400,
+	},
 	EMAIL_NOT_FOUND: {
 		message: '해당 이메일로 가입된 계정이 없습니다.',
 		status: 404,

--- a/backend/src/constants/error/authErrorMessage.js
+++ b/backend/src/constants/error/authErrorMessage.js
@@ -3,6 +3,10 @@ const AuthErrorMessage = {
 		message: '해당 이메일로 가입된 계정이 이미 존재합니다.',
 		status: 409,
 	},
+	DUPLICATED_NICKNAME: {
+		message: '이미 사용 중인 닉네임입니다.',
+		status: 409,
+	},
 	EMAIL_NOT_FOUND: {
 		message: '해당 이메일로 가입된 계정이 없습니다.',
 		status: 404,

--- a/backend/src/controllers/oauthController.js
+++ b/backend/src/controllers/oauthController.js
@@ -1,3 +1,4 @@
+import AuthErrorMessage from '../constants/error/authErrorMessage.js';
 import OAuthService from '../services/oauthService.js';
 import * as tokenUtil from '../utils/tokenUtil.js';
 
@@ -6,7 +7,7 @@ class OAuthController {
 	 * 리디렉션 from Provider
 	 * GET /api/oauth/callback/:provider?code=
 	 */
-	static async socialLogin(req, res) {
+	static async socialLogin(req, res, next) {
 		const userInfo = req.userInfo;
 
 		try {
@@ -19,11 +20,47 @@ class OAuthController {
 			res.redirect(process.env.OAUTH_REDIRECT_URI);
 		} catch (e) {
 			// 소셜 로그인 실패
-			res.redirect(
-				`${process.env.OAUTH_REDIRECT_URI}?error=${encodeURIComponent(
-					e.message,
-				)}`,
-			);
+			console.error('Social login error:', e.message, 'User info:', userInfo);
+			// error handler에 역할 위임
+			return next(e);
+		}
+	}
+
+	/**
+	 * GET /api/oauth/userinfo
+	 */
+	static async getUserInfoFromCookie(req, res) {
+		const userInfo = req.cookies.userInfo;
+
+		if (!userInfo) {
+			return res.status(400).json({ message: '사용자 정보가 없습니다.' });
+		}
+
+		return res.status(200).json({ userInfo: JSON.parse(userInfo) });
+	}
+	/**
+	 * POST /api/oauth/register
+	 */
+
+	static async register(req, res) {
+		const { email, nickname, authProvider } = req.body;
+		if (!email || !nickname || !authProvider) {
+			return res.status(404).json({ message: '필수 정보가 부족합니다.' });
+		}
+		try {
+			const data = await OAuthService.registerMember({
+				email,
+				nickname,
+				password: '',
+				authProvider,
+			});
+			const token = tokenUtil.generateToken(data);
+			tokenUtil.setTokenCookie(res, token);
+			data.message = '회원가입 되었습니다.';
+			return res.status(201).json(data);
+		} catch (e) {
+			console.log(e);
+			return res.status(e.status).json({ message: e.message });
 		}
 	}
 }

--- a/backend/src/lib/oauth2ErrorHandler.js
+++ b/backend/src/lib/oauth2ErrorHandler.js
@@ -1,0 +1,36 @@
+import AuthErrorMessage from '../constants/error/authErrorMessage.js';
+
+const oauth2ErrorHandler = async (err, req, res, next) => {
+	// 닉네임 설정 필요한 경우
+	const userInfo = req.userInfo;
+	if (
+		err.message === AuthErrorMessage.NICKNAME_REQUIRED.message ||
+		err.message === AuthErrorMessage.DUPLICATED_NICKNAME.message
+	) {
+		res.cookie('userInfo', JSON.stringify(userInfo), {
+			httpOnly: true,
+			maxAge: 10 * 60 * 1000, // 10분 후 만료
+		});
+		res.cookie(
+			'errorMessage',
+			JSON.stringify({
+				message: err.message,
+				status: err.status || 500,
+			}),
+			{
+				httpOnly: true,
+				maxAge: 10 * 60 * 1000,
+			},
+		);
+		return res.redirect(`${process.env.OAUTH_REDIRECT_URI}/nickname`);
+	} else {
+		// 기타 에러
+		return res.redirect(
+			`${process.env.OAUTH_REDIRECT_URI}?error=${encodeURIComponent(
+				e.message,
+			)}`,
+		);
+	}
+};
+
+export default oauth2ErrorHandler;

--- a/backend/src/repositories/memberRepository.js
+++ b/backend/src/repositories/memberRepository.js
@@ -22,6 +22,14 @@ class MemberRepository {
 		);
 		return result.rows.length === 0 ? null : result.rows[0];
 	}
+
+	static async findByNickname(nickname) {
+		const result = await pool.query(
+			'SELECT * FROM member WHERE nickname = $1',
+			[nickname],
+		);
+		return result.rows[0];
+	}
 }
 
 export default MemberRepository;

--- a/backend/src/routes/oauthRouter.js
+++ b/backend/src/routes/oauthRouter.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import OAuthController from '../controllers/oauthController.js';
 import oauth2Middleware from '../lib/oauth2/oauth2Middleware.js';
+import oauth2ErrorHandler from '../lib/oauth2ErrorHandler.js';
 
 const oauthRouter = Router();
 
@@ -8,6 +9,8 @@ oauthRouter.get(
 	'/callback/:provider',
 	oauth2Middleware,
 	OAuthController.socialLogin,
+	oauth2ErrorHandler,
 );
-
+oauthRouter.get('/userinfo', OAuthController.getUserInfoFromCookie);
+oauthRouter.post('/register', OAuthController.register);
 export default oauthRouter;

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -37,12 +37,14 @@ class AuthService {
 	}
 
 	static async checkIfEmailExist(email) {
-		if ((await MemberRepository.findByEmail(email)) !== null) {
+		const existedMember = await MemberRepository.findByEmail(email);
+		if (existedMember) {
 			throw new CustomError(AuthErrorMessage.DUPLICATED_EMAIL);
 		}
 	}
 	static async checkIfNicknameIsTaken(nickname) {
-		if ((await MemberRepository.findByNickname(nickname)) !== null) {
+		const existedMember = await MemberRepository.findByNickname(nickname);
+		if (existedMember) {
 			throw new CustomError(AuthErrorMessage.DUPLICATED_NICKNAME);
 		}
 	}

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -5,10 +5,8 @@ import jwt from 'jsonwebtoken';
 
 class AuthService {
 	static async registerMember({ email, password, nickname, authProvider }) {
-		// check if email is already taken
-		if ((await MemberRepository.findByEmail(email)) !== null) {
-			throw new CustomError(AuthErrorMessage.DUPLICATED_EMAIL);
-		}
+		await this.checkIfEmailExist(email);
+		await this.checkIfNicknameIsTaken(nickname);
 
 		await MemberRepository.create({
 			email,
@@ -36,6 +34,17 @@ class AuthService {
 			email: member.email,
 			nickname: member.nickname,
 		};
+	}
+
+	static async checkIfEmailExist(email) {
+		if ((await MemberRepository.findByEmail(email)) !== null) {
+			throw new CustomError(AuthErrorMessage.DUPLICATED_EMAIL);
+		}
+	}
+	static async checkIfNicknameIsTaken(nickname) {
+		if ((await MemberRepository.findByNickname(nickname)) !== null) {
+			throw new CustomError(AuthErrorMessage.DUPLICATED_NICKNAME);
+		}
 	}
 }
 

--- a/backend/src/services/oauthService.js
+++ b/backend/src/services/oauthService.js
@@ -12,7 +12,8 @@ class OAuthService {
 		//  1. 해당 이메일로 가입된 계정이 있는지 확인
 		const member = await MemberRepository.findByEmail(userInfo.email);
 		// 2. 있다면 현재 요청한 플랫폼과 동일한지 확인
-		if (member !== null) {
+
+		if (member !== undefined && member !== null) {
 			if (member.auth_provider === userInfo.authProvider) {
 				// 2-1. 동일하다면 로그인 처리
 				return {
@@ -36,6 +37,16 @@ class OAuthService {
 	}
 
 	static async registerMember({ email, nickname, password, authProvider }) {
+		// 1. userInfo에 nickname이 존재하지 않는 경우
+		if (nickname === undefined || nickname === null) {
+			throw new CustomError(AuthErrorMessage.NICKNAME_REQUIRED);
+		}
+		// 2. 중복된 nickname인 경우
+		const existedMember = await MemberRepository.findByNickname(nickname);
+		if (existedMember) {
+			throw new CustomError(AuthErrorMessage.DUPLICATED_NICKNAME);
+		}
+
 		const member = await MemberRepository.create({
 			email,
 			nickname,

--- a/frontend/src/Router.js
+++ b/frontend/src/Router.js
@@ -10,6 +10,8 @@ import Layout from './containers/common/Layout';
 import MyArticlesPage from './pages/MyArticlesPage';
 import FullArticlesPage from './pages/FullArticlesPage';
 import CalendarPage from './pages/CalendarPage';
+import SetNicknameForm from './containers/auth/SetNicknameForm';
+import NicknameSettingPage from './pages/NicknameSettingPage';
 
 const Router = () => {
 	return (
@@ -26,6 +28,7 @@ const Router = () => {
 				<Route path="/login" element={<LoginPage />} />
 				<Route path="/register" element={<RegisterPage />} />
 				<Route path="/oauth2/redirect" element={<OAuth2RedirectHandler />} />
+				<Route path="/oauth2/redirect/nickname" element={<NicknameSettingPage />} />
 			</Routes>
 		</BrowserRouter>
 	);

--- a/frontend/src/components/auth/AuthForm.js
+++ b/frontend/src/components/auth/AuthForm.js
@@ -30,6 +30,10 @@ const StyledInput = styled.input`
 		color: var(--color-dark);
 		border-bottom: 2px solid var(--color-black);
 	}
+	&:-webkit-autofill {
+		-webkit-box-shadow: 0 0 0 1000px white inset;
+		-webkit-text-fill-color: var(--color-black);
+	}
 `;
 
 const authButtonStyle = css`
@@ -77,6 +81,7 @@ const ErrorMessage = styled.div`
 const textMap = {
 	register: '회원가입',
 	login: '로그인',
+	nicknameRegister: '닉네임 설정',
 };
 
 const AuthForm = ({ type, form, onChange, onSubmit, error }) => {
@@ -89,28 +94,32 @@ const AuthForm = ({ type, form, onChange, onSubmit, error }) => {
 					name="email"
 					placeholder="이메일"
 					onChange={onChange}
-					value={form.email}
+					value={form?.email}
 					required
+					disabled={type === 'nicknameRegister'}
 				/>
-				{type === 'register' && (
+				{(type === 'register' || type === 'nicknameRegister') && (
 					<StyledInput
 						type="text"
 						name="nickname"
 						placeholder="닉네임"
 						onChange={onChange}
-						value={form.nickname}
+						value={form?.nickname}
 						required
 					/>
 				)}
-				<StyledInput
-					type="password"
-					name="password"
-					placeholder="비밀번호"
-					autoComplete="off"
-					onChange={onChange}
-					value={form.password}
-					required
-				/>
+				{type !== 'nicknameRegister' && (
+					<StyledInput
+						type="password"
+						name="password"
+						placeholder="비밀번호"
+						autoComplete="off"
+						onChange={onChange}
+						value={form?.password}
+						required
+					/>
+				)}
+
 				{type === 'register' && (
 					<StyledInput
 						type="password"
@@ -118,7 +127,7 @@ const AuthForm = ({ type, form, onChange, onSubmit, error }) => {
 						placeholder="비밀번호 확인"
 						autoComplete="off"
 						onChange={onChange}
-						value={form.passwordConfirm}
+						value={form?.passwordConfirm}
 						required
 					/>
 				)}
@@ -126,9 +135,8 @@ const AuthForm = ({ type, form, onChange, onSubmit, error }) => {
 				<StyledButton type="submit">확인</StyledButton>
 			</form>
 			<AuthFooter>
-				{type === 'register' ? (
-					<Link to="/login">이미 계정이 있으신가요?</Link>
-				) : (
+				{type === 'register' && <Link to="/login">이미 계정이 있으신가요?</Link>}
+				{type === 'login' && (
 					<>
 						<Link to="/">비밀번호 찾기</Link>
 						<div>|</div>
@@ -136,8 +144,12 @@ const AuthForm = ({ type, form, onChange, onSubmit, error }) => {
 					</>
 				)}
 			</AuthFooter>
-			<Or />
-			<SocialLogin />
+			{type !== 'nicknameRegister' && (
+				<>
+					<Or />
+					<SocialLogin />
+				</>
+			)}
 		</AuthFormBlock>
 	);
 };

--- a/frontend/src/containers/auth/LoginForm.js
+++ b/frontend/src/containers/auth/LoginForm.js
@@ -38,6 +38,7 @@ const LoginForm = () => {
 
 	useEffect(() => {
 		dispatch(initializeForm('login'));
+		return () => dispatch(initializeForm('login'));
 	}, [dispatch]);
 
 	useEffect(() => {

--- a/frontend/src/containers/auth/RegisterForm.js
+++ b/frontend/src/containers/auth/RegisterForm.js
@@ -51,7 +51,7 @@ const RegisterForm = () => {
 	// 첫 렌더링
 	useEffect(() => {
 		dispatch(initializeForm('register'));
-		// TODO: authError가 초기화 되지 않은 상태로 들어오는 이유 확인하기
+		return () => dispatch(initializeForm('register'));
 	}, [dispatch]);
 
 	// 회원가입 성공/실패 처리
@@ -65,7 +65,8 @@ const RegisterForm = () => {
 		}
 		if (auth) {
 			dispatch(check());
-			window.alert('회원가입 되었습니다. 환영합니다!');
+			window.alert(`${form.nickname}님의 가입을 환영합니다!`);
+			navigate('/login');
 		}
 	}, [auth, authError, dispatch]);
 

--- a/frontend/src/containers/auth/SetNicknameForm.js
+++ b/frontend/src/containers/auth/SetNicknameForm.js
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import AuthForm from '../../components/auth/AuthForm';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+	changeField,
+	getUserInfo,
+	initializeForm,
+	registerUserInfo,
+} from '../../modules/auth/auth';
+import { useNavigate } from 'react-router-dom';
+import { check } from '../../modules/user/user';
+
+const SetNicknameForm = () => {
+	const [error, setError] = useState('');
+	const navigate = useNavigate();
+	const dispatch = useDispatch();
+	const form = useSelector((state) => state.auth.userInfo);
+	const auth = useSelector((state) => state.auth.auth);
+	const authError = useSelector((state) => state.auth.authError);
+	const user = useSelector((state) => state.user.user);
+
+	const onChange = (e) => {
+		const { value, name } = e.target;
+		dispatch(
+			changeField({
+				form: 'userInfo',
+				key: name,
+				value: value,
+			}),
+		);
+	};
+
+	const onSubmit = (e) => {
+		e.preventDefault();
+		dispatch(registerUserInfo(form));
+	};
+
+	// inintial rendering
+	useEffect(() => {
+		dispatch(getUserInfo());
+		return () => dispatch(initializeForm('nicknameRegister'));
+	}, [dispatch]);
+
+	useEffect(() => {
+		if (authError) {
+			console.log('회원가입 실패');
+			setError(authError.response.data.message);
+			return;
+		} else {
+			setError(null);
+		}
+		if (auth) {
+			dispatch(check());
+			window.alert(`${form.nickname}님의 가입을 환영합니다!`);
+		}
+	}, [auth, authError, dispatch]);
+
+	useEffect(() => {
+		if (user) {
+			navigate('/');
+			try {
+				localStorage.setItem('user', JSON.stringify(user));
+			} catch (e) {
+				console.log('localStorage is not working');
+			}
+		}
+	}, [user, navigate]);
+
+	return (
+		<AuthForm
+			type="nicknameRegister"
+			form={form}
+			error={error}
+			onChange={onChange}
+			onSubmit={onSubmit}
+		/>
+	);
+};
+
+export default SetNicknameForm;

--- a/frontend/src/modules/auth/auth.js
+++ b/frontend/src/modules/auth/auth.js
@@ -10,6 +10,11 @@ const CHANGE_FIELD = 'auth/CHANGE_FIELD';
 const [REGISTER, REGISTER_SUCCESS, REGISTER_FAILURE] = createRequestActionTypes('auth/REGISTER');
 const [LOGIN, LOGIN_SUCCESS, LOGIN_FAILURE] = createRequestActionTypes('auth/LOGIN');
 
+const [GET_USER_INFO, GET_USER_INFO_SUCCESS, GET_USER_INFO_FAILURE] =
+	createRequestActionTypes('auth/GET_USER_INFO');
+const [REGISTER_USER_INFO, REGISTER_USER_INFO_SUCCESS, REGISTER_USER_INFO_FAILURE] =
+	createRequestActionTypes('auth/REGISTER_USER_INFO');
+
 export const initializeForm = createAction(INITIALIZE_FORM, (form) => form);
 export const changeField = createAction(CHANGE_FIELD, ({ form, key, value }) => ({
 	form, // (register/login)
@@ -25,13 +30,23 @@ export const login = createAction(LOGIN, ({ email, password }) => ({
 	email,
 	password,
 }));
+export const getUserInfo = createAction(GET_USER_INFO);
+export const registerUserInfo = createAction(
+	REGISTER_USER_INFO,
+	({ email, nickname, password, authProvider }) => ({ email, nickname, password, authProvider }),
+);
 
 // ============= redux - saga ================ //
 const registerSaga = createRequestSaga(REGISTER, authAPI.register);
 const loginSaga = createRequestSaga(LOGIN, authAPI.login);
+const getUserInfoSaga = createRequestSaga(GET_USER_INFO, authAPI.getUserInfo);
+const registerUserInfoSaga = createRequestSaga(REGISTER_USER_INFO, authAPI.registerUserInfo);
+
 export function* authSaga() {
 	yield takeLatest(REGISTER, registerSaga);
 	yield takeLatest(LOGIN, loginSaga);
+	yield takeLatest(GET_USER_INFO, getUserInfoSaga);
+	yield takeLatest(REGISTER_USER_INFO, registerUserInfoSaga);
 }
 
 const initialState = {
@@ -44,6 +59,12 @@ const initialState = {
 	login: {
 		email: '',
 		password: '',
+	},
+	userInfo: {
+		email: '',
+		nickname: '',
+		password: '',
+		authProvider: '',
 	},
 	auth: null,
 	authError: null,
@@ -59,6 +80,7 @@ const auth = handleActions(
 			...state,
 			[form]: initialState[form],
 			authError: null,
+			auth: null,
 		}),
 		[REGISTER_SUCCESS]: (state, { payload: auth }) => ({
 			...state,
@@ -75,6 +97,24 @@ const auth = handleActions(
 			auth,
 		}),
 		[LOGIN_FAILURE]: (state, { payload: error }) => ({
+			...state,
+			authError: error,
+		}),
+		[GET_USER_INFO_SUCCESS]: (state, { payload: userInfo }) => ({
+			...state,
+			authError: null,
+			...userInfo,
+		}),
+		[GET_USER_INFO_FAILURE]: (state, { payload: error }) => ({
+			...state,
+			authError: error,
+		}),
+		[REGISTER_USER_INFO_SUCCESS]: (state, { payload: auth }) => ({
+			...state,
+			authError: null,
+			auth,
+		}),
+		[REGISTER_USER_INFO_FAILURE]: (state, { payload: error }) => ({
 			...state,
 			authError: error,
 		}),

--- a/frontend/src/pages/NicknameSettingPage.js
+++ b/frontend/src/pages/NicknameSettingPage.js
@@ -1,0 +1,12 @@
+import AuthTemplate from '../components/auth/AuthTemplate';
+import SetNicknameForm from '../containers/auth/SetNicknameForm';
+
+const NicknameSettingPage = () => {
+	return (
+		<AuthTemplate>
+			<SetNicknameForm />
+		</AuthTemplate>
+	);
+};
+
+export default NicknameSettingPage;

--- a/frontend/src/services/api/authAPI.js
+++ b/frontend/src/services/api/authAPI.js
@@ -12,3 +12,9 @@ export const check = () => client.get('/api/auth/check');
 
 // 로그아웃
 export const logout = () => client.post('/api/auth/logout');
+
+// userInfo 요청
+export const getUserInfo = () => client.get('/api/oauth/userinfo');
+
+// userInfo 등록 요청
+export const registerUserInfo = (userInfo) => client.post('/api/oauth/register', userInfo);


### PR DESCRIPTION
각 사용자의 닉네임이 중복되지 않도록 로직을 변경하고 이를 반영하였습니다.

1. form 회원가입시 닉네임 중복을 확인하고, 중복되지 않는 경우에만 회원가입이 완료됩니다.


2. oauth2 회원가입시 provider로부터 받아온 userInfo에서 닉네임을 확인합니다. 닉네임이 존재하지 않거나, 중복된 닉네임인 경우 새로운 닉네임을 사용자로부터 받아와 회원가입을 마무리하도록 변경하였습니다.

this closes #32 